### PR TITLE
fix(client): stylelint "selector-class-pattern" now allows BEM

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,6 +2,6 @@
   "plugins": ["stylelint-order"],
   "extends": ["stylelint-config-standard-scss", "stylelint-config-prettier-scss", "stylelint-config-hudochenkov/order"],
   "rules": {
-    "selector-class-pattern": "^[a-z][a-zA-Z0-9]+$"
+    "selector-class-pattern": "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:_[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*)?(?:\\[.+\\])?$"
   }
 }


### PR DESCRIPTION
Исправляет паттерн `styelint`, теперь используется camelCase BEM

#### Пример
```css
.blockName {}                                     /* блок */
.blockName__elementName {}                        /* элемент */
.blockName__elementName_booleanModifier {}        /* булевой модификатор */
.blockName__elementName_modifier_modifierValue {} /* ключ-значение модификатор */
```