### PR TITLE
fix(client): jest add identity-obj-proxy mapper for images

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -9,6 +9,9 @@ export default {
     __SERVER_PORT__: process.env.SERVER_PORT,
   },
   moduleNameMapper: {
-    "\\.css$": "identity-obj-proxy"
+    "\\.css$": "identity-obj-proxy",
+    "\\.png$": "identity-obj-proxy",
+    "\\.svg$": "identity-obj-proxy",
+    "\\.jpg$": "identity-obj-proxy",
   }
 }


### PR DESCRIPTION
### Какую задачу решаем
Тесты падают при `import` изображений, добавил `identity-obj-proxy` в `moduleNameMapper`