### PR TITLE
Af 18 add game ending page

### DIFF
--- a/packages/client/src/components/gameDisplay/gameDisplay.tsx
+++ b/packages/client/src/components/gameDisplay/gameDisplay.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useRef } from 'react'
-
 import { GameOverlay } from '../gameOverlay/gameOverlay'
-
 import styles from './gameDisplay.module.css'
 
 export const GameDisplay: React.FC = () => {
@@ -24,7 +22,7 @@ export const GameDisplay: React.FC = () => {
   return (
     <div className={styles.gameDisplay}>
       <canvas ref={gameRef} width={1280} height={720} />
-      <GameOverlay />
+      <GameOverlay onReloadGame={() => undefined} />
     </div>
   )
 }

--- a/packages/client/src/components/gameEnd/gameEnd.module.css
+++ b/packages/client/src/components/gameEnd/gameEnd.module.css
@@ -1,0 +1,27 @@
+.gameEnd {
+  display: flex;
+  flex-direction: column;
+  gap: 50px;
+  width: 1280px;
+  height: 720px;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+}
+
+.gameEndText {
+  font-size: 50px;
+  line-height: 1.2em;
+}
+
+.gameEndButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.gameEndButton {
+  border-color: #fff;
+  background-color: transparent;
+  color: #fff;
+}

--- a/packages/client/src/components/gameEnd/gameEnd.module.css
+++ b/packages/client/src/components/gameEnd/gameEnd.module.css
@@ -24,4 +24,5 @@
   border-color: #fff;
   background-color: transparent;
   color: #fff;
+  text-align: center;
 }

--- a/packages/client/src/components/gameEnd/gameEnd.tsx
+++ b/packages/client/src/components/gameEnd/gameEnd.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { Link } from 'react-router-dom'
+import { getCurrentScore } from '../../store/selectors'
+import { Button } from '../button/button'
+import styles from './gameEnd.module.css'
+import baseStyles from '../../app/app.module.css'
+
+interface Props {
+  onReloadGame: () => void
+}
+
+export const GameEnd: React.FC<Props> = props => {
+  const { onReloadGame } = props
+  const currentScore = useSelector(getCurrentScore)
+
+  return (
+    <div className={styles.gameEnd}>
+      <p className={styles.gameEndText}>Игра окончена!</p>
+      <p className={styles.gameEndText}>
+        Количество набранных очков: {currentScore}
+      </p>
+      <div className={styles.gameEndButtons}>
+        <Link
+          to="/"
+          className={`${baseStyles.linkButton} ${styles.gameEndButton}`}>
+          На главную
+        </Link>
+        <Button onClick={onReloadGame} className={styles.gameEndButton}>
+          Сыграть еще раз
+        </Button>
+        <Link
+          to="/leaderboard"
+          className={`${baseStyles.linkButton} ${styles.gameEndButton}`}>
+          Посмотреть таблицу лидеров
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/packages/client/src/components/gameEnd/gameEnd.tsx
+++ b/packages/client/src/components/gameEnd/gameEnd.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from '../../store/hooks'
 import { Link } from 'react-router-dom'
 import { getCurrentScore } from '../../store/selectors'
 import { Button } from '../button/button'
@@ -12,7 +12,7 @@ interface Props {
 
 export const GameEnd: React.FC<Props> = props => {
   const { onReloadGame } = props
-  const currentScore = useSelector(getCurrentScore)
+  const currentScore = useAppSelector(getCurrentScore)
 
   return (
     <div className={styles.gameEnd}>

--- a/packages/client/src/components/gameOverlay/gameOverlay.tsx
+++ b/packages/client/src/components/gameOverlay/gameOverlay.tsx
@@ -1,15 +1,27 @@
-import { useState } from 'react'
-
+import React from 'react'
+import { useSelector } from 'react-redux'
 import { GameStart } from '../gameStart/gameStart'
-
+import { GameEnd } from '../gameEnd/gameEnd'
+import { GameStatus } from '../../store/gameSlice'
+import { getGameStatus } from '../../store/selectors'
 import styles from './gameOverlay.module.css'
 
-export const GameOverlay: React.FC = () => {
-  const [isStart, setIsStart] = useState(true)
+interface Props {
+  onReloadGame: () => void
+}
 
-  return isStart ? (
-    <div className={styles.gameOverlay}>
-      <GameStart onButtonClick={() => setIsStart(false)} />
-    </div>
-  ) : null
+export const GameOverlay: React.FC<Props> = props => {
+  const { onReloadGame } = props
+  const status = useSelector(getGameStatus)
+  const isRender =
+    status === GameStatus.START || status === GameStatus.END ? true : null
+
+  return (
+    isRender && (
+      <div className={styles.gameOverlay}>
+        {status === GameStatus.START && <GameStart />}
+        {status === GameStatus.END && <GameEnd onReloadGame={onReloadGame} />}
+      </div>
+    )
+  )
 }

--- a/packages/client/src/components/gameOverlay/gameOverlay.tsx
+++ b/packages/client/src/components/gameOverlay/gameOverlay.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from '../../store/hooks'
 import { GameStart } from '../gameStart/gameStart'
 import { GameEnd } from '../gameEnd/gameEnd'
 import { GameStatus } from '../../store/gameSlice'
@@ -12,7 +12,7 @@ interface Props {
 
 export const GameOverlay: React.FC<Props> = props => {
   const { onReloadGame } = props
-  const status = useSelector(getGameStatus)
+  const status = useAppSelector(getGameStatus)
   const shouldRenderOverlay =
     status === GameStatus.START || status === GameStatus.END
 

--- a/packages/client/src/components/gameOverlay/gameOverlay.tsx
+++ b/packages/client/src/components/gameOverlay/gameOverlay.tsx
@@ -13,15 +13,13 @@ interface Props {
 export const GameOverlay: React.FC<Props> = props => {
   const { onReloadGame } = props
   const status = useSelector(getGameStatus)
-  const isRender =
-    status === GameStatus.START || status === GameStatus.END ? true : null
+  const shouldRenderOverlay =
+    status === GameStatus.START || status === GameStatus.END
 
-  return (
-    isRender && (
-      <div className={styles.gameOverlay}>
-        {status === GameStatus.START && <GameStart />}
-        {status === GameStatus.END && <GameEnd onReloadGame={onReloadGame} />}
-      </div>
-    )
-  )
+  return shouldRenderOverlay ? (
+    <div className={styles.gameOverlay}>
+      {status === GameStatus.START && <GameStart />}
+      {status === GameStatus.END && <GameEnd onReloadGame={onReloadGame} />}
+    </div>
+  ) : null
 }

--- a/packages/client/src/components/gameStart/gameStart.tsx
+++ b/packages/client/src/components/gameStart/gameStart.tsx
@@ -1,15 +1,11 @@
 import { Button } from '../button/button'
-
 import styles from './gameStart.module.css'
-
 import keyboard from '../../assets/images/keyboard.png'
+import { useAppDispatch } from '../../store/hooks'
+import { GameStatus, setStatus } from '../../store/gameSlice'
 
-interface Props {
-  onButtonClick: () => void
-}
-
-export const GameStart = (props: Props) => {
-  const { onButtonClick } = props
+export const GameStart: React.FC = () => {
+  const dispatch = useAppDispatch()
 
   return (
     <div className={styles.gameStart}>
@@ -21,7 +17,9 @@ export const GameStart = (props: Props) => {
         alt="Клавиатура"
         draggable={false}
       />
-      <Button className={styles.gameStartButton} onClick={onButtonClick}>
+      <Button
+        className={styles.gameStartButton}
+        onClick={() => dispatch(setStatus(GameStatus.IN_PROGRESS))}>
         ПОНЯЛ, ПОГНАЛИ!
       </Button>
     </div>

--- a/packages/client/src/store/gameSlice.ts
+++ b/packages/client/src/store/gameSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+export enum GameStatus {
+  START = `start`,
+  IN_PROGRESS = `inProgress`,
+  END = `end`,
+}
+
+type State = {
+  status: GameStatus
+  currentScore: number
+}
+
+const INITIAL_STATE: State = {
+  status: GameStatus.START,
+  currentScore: 0,
+}
+
+const gameSlice = createSlice({
+  name: 'game',
+  initialState: INITIAL_STATE,
+  reducers: {
+    setStatus: (state, action: PayloadAction<GameStatus>) => {
+      state.status = action.payload
+    },
+    setCurrentScore: (state, action: PayloadAction<number>) => {
+      state.currentScore = action.payload
+    },
+  },
+})
+
+export const gameReducer = gameSlice.reducer
+export const { setStatus, setCurrentScore } = gameSlice.actions

--- a/packages/client/src/store/index.tsx
+++ b/packages/client/src/store/index.tsx
@@ -1,9 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { userReducer } from './userSlice'
 import { playersStatsReducer } from './playersStatsSlice'
+import { gameReducer } from './gameSlice'
 
 export const store = configureStore({
-  reducer: { user: userReducer, playersStats: playersStatsReducer },
+  reducer: {
+    user: userReducer,
+    playersStats: playersStatsReducer,
+    game: gameReducer,
+  },
 })
 
 export type RootState = ReturnType<typeof store.getState>

--- a/packages/client/src/store/selectors.ts
+++ b/packages/client/src/store/selectors.ts
@@ -2,3 +2,5 @@ import { RootState } from './index'
 
 export const getUser = (state: RootState) => state.user
 export const getPlayersStats = (state: RootState) => state.playersStats
+export const getCurrentScore = (state: RootState) => state.game.currentScore
+export const getGameStatus = (state: RootState) => state.game.status


### PR DESCRIPTION
### Какую задачу решаем
Добавил экран завершения игры.

Что было сделано:

- Добавил [gameSlice](https://github.com/Aleksandr-86/canvas-bomberman/blob/af-18-add-game-ending-page/packages/client/src/store/gameSlice.ts), который необходим, чтобы хранить состояние (статус) в котором игра находится и текущее количество очков
- Отрефакторил компонент [GameOverlay](https://github.com/Aleksandr-86/canvas-bomberman/blob/af-18-add-game-ending-page/packages/client/src/components/gameOverlay/gameOverlay.tsx), теперь он не содержит локальный стейт, а получает данные из редакса, смотрим на gameStatus, если игра только начинается, то отрисовывает компонент GameStart, если окончена то GameEnd, если в процессе, то ничего не рисует.
- Отрефакторил компонент [GameStart](https://github.com/Aleksandr-86/canvas-bomberman/blob/af-18-add-game-ending-page/packages/client/src/components/gameStart/gameStart.tsx), ему теперь не требуется props, он изменяет статус игры на  прогресс с помощью редакса.
- Добавил компонент [GameEnd](https://github.com/Aleksandr-86/canvas-bomberman/blob/af-18-add-game-ending-page/packages/client/src/components/gameEnd/gameEnd.tsx), его внешний вид на скриншоте

### Скриншоты/видяшка (если есть)
![game-end](https://user-images.githubusercontent.com/96945167/213191849-d30932fb-96ea-4911-a102-33503e6c578b.jpg)

### TBD (если есть)