### PR TITLE
af-88-configure-the-csp

### DIFF
--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -1,3 +1,4 @@
+import { cspMiddleware } from './middlewares/cspMiddleware'
 import dotenv from 'dotenv'
 import cors from 'cors'
 import { createServer as createViteServer } from 'vite'
@@ -17,6 +18,7 @@ async function startServer() {
   const port = Number(process.env.SERVER_PORT) || 3001
 
   app.use(cors())
+  app.use(cspMiddleware())
 
   let vite: ViteDevServer | undefined
 
@@ -115,6 +117,7 @@ async function startServer() {
         .replace(`<!--ssr-styles-->`, cssAssets)
         .replace(`<!--ssr-outlet-->`, appHtml)
         .replace(`<!--ssr-store-->`, appStore)
+        .replace(/<script/g, `<script nonce="${req.nonce}"`)
 
       res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
     } catch (e) {

--- a/packages/server/middlewares/cspMiddleware.ts
+++ b/packages/server/middlewares/cspMiddleware.ts
@@ -1,0 +1,18 @@
+import { expressCspHeader, SELF, NONE, NONCE, INLINE } from 'express-csp-header'
+
+const API_URL = 'https://ya-praktikum.tech'
+
+export const cspMiddleware = () =>
+  expressCspHeader({
+    directives: {
+      'default-src': [SELF, API_URL, 'ws://localhost:24678'],
+      'font-src': [SELF],
+      'media-src': [SELF],
+      'object-src': [NONE],
+      'script-src': [NONCE],
+      'style-src': [SELF, INLINE],
+      'worker-src': [SELF],
+      'frame-ancestors': [NONE],
+      'form-action': [NONE],
+    },
+  })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
     "cors": "2.8.5",
     "dotenv": "16.0.2",
     "express": "4.18.1",
+    "express-csp-header": "5.1.0",
     "pg": "8.8.0",
     "rimraf": "4.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7854,6 +7854,7 @@
     "cors" "2.8.5"
     "dotenv" "16.0.2"
     "express" "4.18.1"
+    "express-csp-header" "^5.1.0"
     "pg" "8.8.0"
     "rimraf" "4.1.2"
 


### PR DESCRIPTION
<details>
<summary>Настроил "Политику Безопасного Содержания" (Content Security Policy).</summary>

![image](https://user-images.githubusercontent.com/96790009/223276669-51da3430-90de-4850-8421-934a8627476c.png)

</details>

Разрешение на использование скриптов выдаётся посредством передачи в атрибут `nonce`  HTML элемента `script` криптографического одноразового номера, генерируемого библиотекой `express-csp-header`

### Примечания:
Использовать аналогичный подход в отношении стилей (CSP директива `style-src` ) не удалось, несмотря на то, что и в [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#:~:text=%3Cstyle%20nonce%3D%222726c7f26c%22%3E) и в спецификации [W3C](https://www.w3.org/TR/CSP3/#grammardef-nonce-source:~:text=Inline%20style%20blocks,the%20inline%20block.) упоминается о схожей с директивой `script-src` возможности.

HTML элемент `style` содержит нужный атрибут с одноразовым номером и при этом стили не блокируются (что видно по оформлению страницы):
<details>
<summary>Снимок</summary>

![image](https://user-images.githubusercontent.com/96790009/223280877-e438c724-53ce-495a-8334-520b7ad9fe9e.png)

</details>

Однако при этом консоль указывает на нарушение правила CSP:
<details>
<summary>Снимок</summary>

![image](https://user-images.githubusercontent.com/96790009/223281563-ad9f01bf-eaaa-4e24-8255-c5a576303c54.png)

</details>

В этой связи пришлось смягчить политику CSP директивы `style-src`, использовав значения `self` и `unsafe-inline`

